### PR TITLE
Update integration paths to have no required properties

### DIFF
--- a/integration-set.schema.yaml
+++ b/integration-set.schema.yaml
@@ -81,8 +81,7 @@ properties:
         $ref: "#/definitions/webLink"
   integrationPaths:
     type: object
-    required:
-    - ordering
+    required: []
     additionalProperties: false
     properties:
       ordering:


### PR DESCRIPTION
Fix issue where @jrameuwissen is making an integration with just `trackingCollection` (and no `ordering`), see https://github.com/ShipitSmarter/stitch-integrations/pull/790 .