### PR TITLE
fix: load list rename

### DIFF
--- a/integration-set.schema.yaml
+++ b/integration-set.schema.yaml
@@ -219,9 +219,9 @@ properties:
         type: array
         items:
           $ref: "#/definitions/integrationPath"
-      loadingList:
-        title: Loading List
-        description: Generate a loading list document for a single or batch of shipments.
+      loadList:
+        title: Load List
+        description: Generate a load list document for a single or batch of shipments.
         link:
           $ref: "#/definitions/webLink"
         type: array


### PR DESCRIPTION
This pull request updates the schema definition in `integration-set.schema.yaml` to correct the naming of a property related to shipment documents.

Schema property correction:

* Renamed the `loadingList` property to `loadList`, updating its title and description to match the new name and ensure consistency in terminology.