### PR TITLE
feat: add document-template.schema.yaml

### DIFF
--- a/document-template.schema.yaml
+++ b/document-template.schema.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=http://json-schema.org/draft-07/schema
+type: object
+required:
+  - reference
+  - integrationPath
+  - samples
+additionalProperties: false
+properties:
+  reference:
+    type: string
+    description: Unique identifier for this document template.
+  integrationPath:
+    type: string
+    description: The Stitch integration path used to render this document template.
+  samples:
+    type: array
+    description: List of sample models available for previewing this document template.
+    items:
+      type: object
+      required:
+        - title
+        - reference
+        - filename
+      additionalProperties: false
+      properties:
+        title:
+          type: string
+          description: Human-readable display name for the sample.
+        reference:
+          type: string
+          description: Unique identifier for this sample within the template.
+        filename:
+          type: string
+          description: Path to the sample JSON file, relative to the document-template.yaml directory.

--- a/integration.schema.json
+++ b/integration.schema.json
@@ -592,6 +592,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "Preview": {
+          "type": "string",
+          "description": "Whether to return a preview HTML. Scriban template will be evaluated."
         }
       },
       "required": [


### PR DESCRIPTION
## Summary

- Adds `document-template.schema.yaml` — a YAML schema (JSON Schema draft-07) for `document-template.yaml` files used across the document template preview feature
- Validates three required fields: `reference` (string), `integrationPath` (string), and `samples` (array of objects with `title`, `reference`, `filename`)
- Strict `additionalProperties: false` throughout, consistent with `integration-set.schema.yaml`

## Context

Part of the document template preview feature. The `document-template.yaml` files live at `files/documents/v2/{doctype}/document-template.yaml` in stitch-integrations. This schema enables editor validation for those files.